### PR TITLE
fix: leser alle build_args, ikke bare første (noref)

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -116,7 +116,7 @@ jobs:
         BASE_IMAGE=ghcr.io/statens-pensjonskasse/rockylinux:9-minimal,
         NODEJS_VERSION=${{ matrix.version.nodejs }},
         NPM_VERSION=${{ matrix.version.npm }},
-        ADDITIONAL_PACKAGES=${{ matrix.type.additional_packages }}
+        ADDITIONAL_PACKAGES=\"${{ matrix.type.additional_packages }}\"
       platforms: linux/amd64
       description: "Node.js ${{ matrix.version.nodejs }}${{ matrix.type.tag }} container image based on Rocky Linux 9 minimal for SPK"
 


### PR DESCRIPTION
Fant at 3.12-imaget til Python har installert kun 3.11.

Kan se ut som denne koden leser kun første linje av build_arg'ene: https://github.com/statens-pensjonskasse/base-images/blob/f8d9dc50ddb40b75cabf444fb276e9f50ec79df0/.github/workflows/podman-build-and-publish.yaml#L105 , i alle fall sendes det kun med ett build arg i denne kjøringen: https://github.com/statens-pensjonskasse/base-images/actions/runs/16555740652/job/46816977342, dermed blir ikke PYTHON_VERSION overstyrt.

Prøver å folde yaml-linjene, dvs. fjerne linjeskift.