### PR TITLE
feat(rocky): legger til interne yum-repos og script for å switche (noref)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,15 @@ Available versions:
 * `9`
 * `9-minimal`
 
-Please note that the yum repositories for Docker, Microsoft and EPEL point to the
-external sites, not to our internal Satellite as before.
+### Yum repositories
 
-Our internal EL repositories on yum.spk.no are disabled in the repo file (with `enabled=0`),
-so that they can be used in cloud builds.
-If you need to install applications from yum.spk.no, you need to build on our internal runners, and enable the repos in
-your Containerfile with something like this:
+As default, only standard external yum repositories are enabled, no internal SPK repos.
+That means you can use it on cloud runners.
 
-```Dockerfile
-RUN sed -i 's/^enabled=0/enabled=1/' /etc/yum.repos.d/spk*.repo
-```
+If you need to install SPK-RPMs, you need to build on our internal runners,
+enable the SPK repos, and disable the mirrorlist in the standard repos.
+The repo config can be done by running the script `yum-switch-to-internal-repos.sh`
+in your build file, as root, before `dnf install`.
 
 ## ☕️ Zulu OpenJDK
 

--- a/rocky-linux/Containerfile
+++ b/rocky-linux/Containerfile
@@ -36,7 +36,10 @@ RUN curl -sSL -O https://packages.microsoft.com/config/rhel/${OS_VERSION}/packag
     && rpm -ivh ./packages-microsoft-prod.rpm \
     && rm -f packages-microsoft-prod.rpm
 
+# Add script for enabling internal Yum repositories (and disabling mirrorlists)
+COPY yum-switch-to-internal-repos.sh /usr/local/bin/
 # Evaluate templates for internal Yum repositories
+# Put them in /etc/yum.repos-internal.d so they can be enabled by the enable-internal-yum-repos.sh script
 RUN --mount=type=bind,src=repos,dst=/tmp/repos \
     if [ "${TARGETARCH}" = "amd64" ]; then \
         ARCH=x86_64; \
@@ -46,12 +49,10 @@ RUN --mount=type=bind,src=repos,dst=/tmp/repos \
         echo "Error: Target architecture '${TARGETARCH}' is not supported" && \
         exit 1; \
     fi; \
+    mkdir -p /etc/yum.repos-internal.d; \
     for REPO in /tmp/repos/*; do \
-        eval "echo \"$(cat ${REPO})\"" > /etc/yum.repos.d/$(basename ${REPO} .tmpl); \
+        eval "echo \"$(cat ${REPO})\"" > /etc/yum.repos-internal.d/$(basename ${REPO} .tmpl); \
     done;
-
-# Disable internal Yum repositories so we can run install on cloud runners
-RUN sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/spk*.repo
 
 # Set locale
 ENV LANG=en_US.UTF-8 \

--- a/rocky-linux/repos/docker.repo.tmpl
+++ b/rocky-linux/repos/docker.repo.tmpl
@@ -1,0 +1,7 @@
+# Repo i Satellite oppdateres fra https://download.docker.com/linux/centos/${OS_VERSION}/${ARCH}/stable/ hver natt.
+# Versjoner i repo installeres i swarmene og standalone servere under vedlikehold.
+[docker-el${OS_VERSION}]
+name=Docker repo for ${OS_VERSION} i Satellite
+baseurl=https://rhs50.spk.no/pulp/content/SPK/Library/custom/Docker_RHEL${OS_VERSION}/Docker_RHEL${OS_VERSION}/
+enabled=1
+gpgcheck=0

--- a/rocky-linux/repos/microsoft.repo.tmpl
+++ b/rocky-linux/repos/microsoft.repo.tmpl
@@ -1,0 +1,8 @@
+# Repoet er kalt "Powershell" i vår Satellite, men det refererer egentlig til Microsoft sitt
+# repo, ref. https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software
+[microsoft-el${OS_VERSION}]
+name = Microsoft EL${OS_VERSION}
+baseurl = http://rhs50.spk.no/pulp/content/SPK/Library/custom/${MICROSOFT_REPO_NAME}${OS_VERSION}/${MICROSOFT_REPO_NAME}${OS_VERSION}/
+metadata_expire = 1
+enabled = 1
+gpgcheck = 0

--- a/rocky-linux/repos/spk-epel.repo.tmpl
+++ b/rocky-linux/repos/spk-epel.repo.tmpl
@@ -1,0 +1,6 @@
+[spk-epel${OS_VERSION}-${ARCH}]
+name = SPK EPEL ${OS_VERSION} ${ARCH}
+baseurl = https://rhs50.spk.no/pulp/content/SPK/Library/custom/EPEL_${OS_VERSION}_Fed/EPEL_${OS_VERSION}_Fed/
+metadata_expire = 1
+enabled = 1
+gpgcheck = 0

--- a/rocky-linux/repos/zulu-openjdk.repo.tmpl
+++ b/rocky-linux/repos/zulu-openjdk.repo.tmpl
@@ -1,0 +1,6 @@
+[zulu-openjdk]
+metadata_expire = 1
+baseurl = http://rhs50.spk.no/pulp/repos/SPK/Library/custom/AzulZuluJDK/AzulZuluJDK/
+name = zulu-openjdk - Azul Systems Inc., Zulu packages
+enabled = 1
+gpgcheck = 0

--- a/rocky-linux/yum-switch-to-internal-repos.sh
+++ b/rocky-linux/yum-switch-to-internal-repos.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+[[ -n "$DEBUG" ]] && set -x  # turn -x on if DEBUG is set to a non-empty string
+set -o errexit # Avslutter umiddelbart hvis et statement returnerer false
+
+cd /etc/yum.repos.d
+
+sed -i 's/^mirrorlist=/#mirrorlist=/' rocky*.repo
+sed -i 's/^#baseurl=/baseurl=/' rocky*.repo epel*.repo
+sed -i 's/^metalink=/#metalink=/' rocky*.repo
+
+cp -vp /etc/yum.repos-internal.d/* .
+rm -v docker-ce.repo microsoft-prod.repo epel*.repo


### PR DESCRIPTION
Kjører man enable-internal-yum-repos.sh i byggene som bruker denne, skal dnf hente filer kun fra interne repos på yum.spk.no eller sites som er åpne for runnerne.
Muliggjør å installere egenbygde RPM'er.