### PR TITLE
feat: legger til otel agent for auto traces (PLAT-5883)

### DIFF
--- a/zulu-openjdk/Containerfile
+++ b/zulu-openjdk/Containerfile
@@ -5,6 +5,7 @@ ARG JAVA_VERSION=21
 ARG JAVA_TYPE=jdk
 ARG PACKAGE_MANAGER=microdnf
 ARG PACKAGE_MANAGER_FLAGS="--assumeyes --nodocs --setopt=install_weak_deps=0"
+ARG OTEL_VERSION=2.10.0
 
 USER root
 
@@ -22,5 +23,11 @@ ENV JAVA_HOME=/usr/lib/jvm/zulu${JAVA_VERSION}
 # Change truststore to include SPK root CA
 RUN rm -f ${JAVA_HOME}/lib/security/cacerts && \
     ln -s /etc/pki/java/cacerts ${JAVA_HOME}/lib/security/cacerts
+
+# Add OpenTelemetry Java agent for auto-instrumentation
+RUN mkdir -p /opt/opentelemetry && \
+    curl -sSL -o /opt/opentelemetry/javaagent.jar \
+    https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/opentelemetry-javaagent.jar && \
+    chmod 644 /opt/opentelemetry/javaagent.jar
 
 USER app


### PR DESCRIPTION
OpenTelemetry Java Agent:
-------------------------

For å får auto-tracing av request boundaries (app->db->app | app->mq->app) i java applikasjoner så trenger vi å legge til opentelemetry javaagent for appene i klusteret.

Her har jeg lagt til otel agent jar i zulujdk base imaget, envvar injecting i spk-app-helm-chart og et av/på flagg i compose-to-helm.

Fordelen med dette er at det sparer utviklere for endringer i appene og vi kan slå otel agenten av og på. For ikke java baserte apper så skjer absolutt ingenting, så der må vi finne en annen instrumentering for Reacts, osv.


Endringer i base java image der vi legger til otel agent jar:

https://github.com/statens-pensjonskasse/base-images/pull/42

Endringer i compose-to-helm hvor vi leggert til otel agent bool flag i values.yaml om ønskelig

https://github.com/statens-pensjonskasse/compose-to-helm/pull/52

Endringer i SPK app helm chart der vi aktiverer otel agenten om flagget er satt i values.yaml

https://github.com/statens-pensjonskasse/spk-app-helm-chart/pull/88
